### PR TITLE
Fix 100-count calculation sometimes hanging and underflowing

### DIFF
--- a/pp_calc.cc
+++ b/pp_calc.cc
@@ -35,25 +35,11 @@ f64 pp_calc_acc(f64 aim, f64 speed, beatmap& b, f64 acc_percent, u32 used_mods,
 	u16 combo, u16 misses, u32 score_version) {
 
 	acc_percent = std::max(0.0, std::min(100.0, acc_percent));
-	u16 c300 = (u16)b.num_objects - misses, c50 = 0, c100 = 0;
 
-	// epsilon is half of the smallest accuracy step that you can get by 
-	// changing 100 count the given accuracy is rounded to the closest possible
-	// acc that you can actually get on the map
-	f64 epsilon = acc_calc(c300, c100, c50, misses) - 
-		acc_calc(c300 - 1, c100 + 1, c50, misses);
+	u16 c100 = std::round(-3.0 * ((acc_percent * 0.01 - 1.0) * b.num_objects + misses) * 0.5);
+	u16 c300 = b.num_objects - c100 - misses;
 
-	epsilon *= 50.0;
-
-	f64 closest_acc;
-	while (std::abs((closest_acc = acc_calc(c300, c100, 0, misses) * 100.0 
-				- acc_percent)) >= epsilon && closest_acc < acc_percent) {
-		
-		c300--;
-		c100++;
-	}
-
-	return pp_calc(aim, speed, b, used_mods, combo, misses, c300, c100, c50, 
+	return pp_calc(aim, speed, b, used_mods, combo, misses, c300, c100, 0, 
 		score_version);
 }
 


### PR DESCRIPTION
In some cases (e.g. https://osu.ppy.sh/b/909244 at 98% accuracy) the accuracy calculation will not result in correct counts, but will instead underflow and result in huge amounts of pp.

The formula is derived by [solving](https://www.wolframalpha.com/input/?i=a+%3D+%28c+%2B+%28t+-+c+-+m%29+*+3%29+%2F+%28t+*+3%29+solve+c) the following equation for c100:

```
accuracy = (c100 + c300 * 3) / (totalHits * 3)
```

... where c300 can be replaced with `totalHits - c100 - misses`, resulting in

```
accuracy = (c100 + (totalHits - c100 - misses) * 3) / (totalHits * 3)
```
