### PR TITLE
Don't round pp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ obj
 *.tar.gz
 *.swp
 *~
+build/

--- a/main.cc
+++ b/main.cc
@@ -112,6 +112,7 @@ print_sig(text_print) {
 	aim = std::round(aim * 100.0) / 100.0;
 	speed = std::round(speed * 100.0) / 100.0;
 	stars = std::round(stars * 100.0) / 100.0;
+	res.pp = std::round(res.pp * 100.0) / 100.0;
 
 	printf("o p p a i | v%s\n", version_string);
 	puts("s     d n | ");

--- a/pp_calc.cc
+++ b/pp_calc.cc
@@ -201,14 +201,12 @@ pp_calc_result pp_calc(f64 aim, f64 speed, beatmap& b,
 		final_multiplier *= 0.95;
 	}
 
-	f64 pp = std::pow(
+	res.pp = std::pow(
 			std::pow(aim_value, 1.1) +
 			std::pow(speed_value, 1.1) +
 			std::pow(acc_value, 1.1), 
 			1.0 / 1.1
 		) * final_multiplier;
-
-	res.pp = std::round(pp * 100.0) / 100.0;
 
 	return res;
 }


### PR DESCRIPTION
In the spirit of 2ec7b4be91b7aa3124058b7b0f0a0db14d660e41 don't round the pp-value.
Moved the rounding to the txt-module output, this way the json (and i guess those binary as well) have pull precision.

(oh and I also added the build directory to the gitignore, was a little annoying xd)
