### PR TITLE
Support compiling in OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ to do is supply it with the map's .osu file.
 - [Caching beatmaps](#caching-beatmaps)
 - [Compiling from source (Linux)](#compiling-from-source-linux)
 - [Compiling from source (Windows)](#compiling-from-source-windows)
+- [Compiling from source (OSX)](#compiling-from-source-osx)
 - [Library mode and bindings](#library-mode-and-bindings)
 
 # Getting started
@@ -108,6 +109,28 @@ build.bat
 ```
 
 The executable will be found in the build directory.
+
+# Compiling from source (OSX)
+Via homebrew:
+```bash
+brew install --HEAD pmrowla/homebrew-tap/oppai
+```
+Note that installing with ```--HEAD``` is not required, but it is recommended
+since the tap may not always be up to date with the current oppai release
+tarball. Installing from homebrew will place the executable in your homebrew
+path.
+
+Compiling from source in OSX will still require the use of homebrew since Apple
+no longer bundles OpenSSL headers with OSX. Also note that homebrew may give
+warnings about not symlinking OpenSSL, this is intended behavior and you should
+not ```brew link --force openssl``` due to potential conflicts with the Apple
+bundled OpenSSL.
+```bash
+brew install openssl
+git clone https://github.com/Francesco149/oppai.git
+cd oppai
+./build-osx.sh
+```
 
 # Library mode and bindings
 oppai can now be compiled in library mode by defining OPPAI_LIB=1. this allows

--- a/beatmap_unix.cc
+++ b/beatmap_unix.cc
@@ -4,9 +4,21 @@
 #include <sys/stat.h>
 #define mkdir(x) mkdir(x, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
 
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
+
 internalfn
 size_t get_exe_path(char* buf, size_t bufsize)
 {
+#ifdef __APPLE__
+    uint32_t size = bufsize;
+
+    if (_NSGetExecutablePath(buf, &size) == 0)
+    {
+        return (size_t)size;
+    }
+#else
     ssize_t res;
 
     res = readlink("/proc/self/exe", buf, bufsize);
@@ -23,6 +35,7 @@ size_t get_exe_path(char* buf, size_t bufsize)
     if (res >= 0) {
         return (size_t)res;
     }
+#endif
 
     perror("readlink");
     strcpy(buf, ".");

--- a/build-osx.sh
+++ b/build-osx.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+${CXX:-clang++}     \
+    -I$(brew --prefix)/opt/openssl/include \
+    -L$(brew --prefix)/opt/openssl/lib \
+    -std=c++98      \
+    -pedantic       \
+    -O2             \
+    $@              \
+    -Wno-variadic-macros \
+    -Wall -Werror   \
+    main.cc         \
+    -lm -lstdc++    \
+    -lcrypto        \
+    -o oppai


### PR DESCRIPTION
The only difference for OSX vs linux is that you can't readlink /proc to get the executable path.

This also requires the use of homebrew, since Apple doesn't include the dev headers for the OpenSSL release that's packaged with the OS. Right now it's set up to use my [tap](https://github.com/pmrowla/homebrew-tap/blob/master/oppai.rb), but if you'd rather host your own you can just copy my formula. I'm not sure if you'll want to keep the separate osx build script or not, but I added it since building in OSX requires passing the include and library search paths for homebrew's OpenSSL in the cflags.