### PR TITLE
Fix build.cpp starting with a capital letter in the build scripts

### DIFF
--- a/java-oppai/src/build.bat
+++ b/java-oppai/src/build.bat
@@ -18,7 +18,7 @@ cl /D_CRT_SECURE_NO_WARNINGS=1 ^
 	/F8000000 ^
 	%CXXFLAGS%  ^
 	/Fe"oppai.dll" ^
-	Build.cpp ^
+	build.cpp ^
 	Advapi32.lib
 
 	

--- a/java-oppai/src/build.sh
+++ b/java-oppai/src/build.sh
@@ -14,7 +14,7 @@ if [ $(uname) = "Darwin" ]; then
 		$@									\
 		-Wno-variadic-macros				\
 		-Wall -Werror						\
-		Build.cpp							\
+		build.cpp							\
 		-lm -lstdc++						\
 		-lcrypto							\
 		-o liboppai.jnilib
@@ -31,7 +31,7 @@ else
 		$@						\
 		-Wno-variadic-macros	\
 		-Wall -Werror			\
-		Build.cpp				\
+		build.cpp				\
 		-lm -lstdc++			\
 		-lcrypto				\
 		-o liboppai.so


### PR DESCRIPTION
on windows the compiler didn't care about the capital letter but on linux it wouldn't compile because of it.